### PR TITLE
Implement glyph death reporting

### DIFF
--- a/app/src/main/java/com/wafitz/pixelspacebase/actors/Char.java
+++ b/app/src/main/java/com/wafitz/pixelspacebase/actors/Char.java
@@ -167,10 +167,8 @@ public abstract class Char extends Actor {
 				if (enemy == Dungeon.hero) {
 
 					if (Dungeon.hero.killerGlyph != null) {
-
-						// FIXME
-					//	Dungeon.fail( Utils.format( ResultDescriptions.GLYPH, Dungeon.hero.killerGlyph.name(), Dungeon.depth ) );
-					//	GLog.n( TXT_KILL, Dungeon.hero.killerGlyph.name() );
+                                                Dungeon.fail( Utils.format( ResultDescriptions.GLYPH, Dungeon.hero.killerGlyph.name(), Dungeon.depth ) );
+                                                GLog.n( TXT_KILL, Dungeon.hero.killerGlyph.name() );
 
 					} else {
 						if (Bestiary.isBoss( this )) {

--- a/app/src/main/java/com/wafitz/pixelspacebase/items/armor/glyphs/Viscosity.java
+++ b/app/src/main/java/com/wafitz/pixelspacebase/items/armor/glyphs/Viscosity.java
@@ -124,10 +124,9 @@ public class Viscosity extends Glyph {
 			if (target.isAlive()) {
 				
 				target.damage( 1, this );
-				if (target == Dungeon.hero && !target.isAlive()) {
-					// FIXME
-					Dungeon.fail( Utils.format( ResultDescriptions.GLYPH, "enchantment of viscosity", Dungeon.depth ) );
-					GLog.n( "The enchantment of viscosity killed you..." );
+                                if (target == Dungeon.hero && !target.isAlive()) {
+                                        Dungeon.fail( Utils.format( ResultDescriptions.GLYPH, "enchantment of viscosity", Dungeon.depth ) );
+                                        GLog.n( "The enchantment of viscosity killed you..." );
 					
 					Badges.validateDeathFromGlyph();
 				}


### PR DESCRIPTION
## Summary
- finalize glyph death logic
- show death messages from viscosity glyph

## Testing
- `./gradlew -version --no-daemon` *(fails: Could not determine java version)*

------
https://chatgpt.com/codex/tasks/task_e_686be667c6ec8326931469b7406be601